### PR TITLE
Use upstream Nextcloud chart

### DIFF
--- a/kubernetes/apps/nextcloud/app/base/helm.yaml
+++ b/kubernetes/apps/nextcloud/app/base/helm.yaml
@@ -8,7 +8,7 @@ spec:
   timeout: 20m # Nextcloud takes a long time to come up
   chart:
     spec:
-      chart: nextcloud-aio/nextcloud-aio-helm-chart
+      chart: nextcloud-aio-helm-chart
       version: 13.3.1
       sourceRef:
         kind: HelmRepository

--- a/kubernetes/apps/nextcloud/app/base/helm.yaml
+++ b/kubernetes/apps/nextcloud/app/base/helm.yaml
@@ -8,11 +8,11 @@ spec:
   timeout: 20m # Nextcloud takes a long time to come up
   chart:
     spec:
-      chart: nextcloud-aio-helm-chart
-      version: 13.2.2
+      chart: nextcloud-aio/nextcloud-aio-helm-chart
+      version: 13.3.1
       sourceRef:
-        kind: GitRepository
-        name: nextcloud-git
+        kind: HelmRepository
+        name: nextcloud
         namespace: flux-system
   postRenderers:
     - kustomize:
@@ -28,6 +28,24 @@ spec:
               - op: replace
                 path: /spec/template/spec/terminationGracePeriodSeconds
                 value: 300
+          - target:
+              version: v1
+              kind: Service
+              name: nextcloud-aio-apache
+            patch: |
+              - op: remove
+                path: /spec/externalTrafficPolicy
+              - op: replace
+                path: /spec/type
+                value: ClusterIP
+          - target:
+              version: v1
+              kind: Service
+              name: nextcloud-aio-talk-public
+            patch: |
+              - op: replace
+                path: /spec/type
+                value: ClusterIP
   releaseName: nextcloud
   targetNamespace: nextcloud
   install:

--- a/kubernetes/clusters/prod/repositories/helm/nextcloud-helmrepo.yaml
+++ b/kubernetes/clusters/prod/repositories/helm/nextcloud-helmrepo.yaml
@@ -1,16 +1,9 @@
 ---
 apiVersion: source.toolkit.fluxcd.io/v1
-kind: GitRepository
+kind: HelmRepository
 metadata:
-  name: nextcloud-git
+  name: nextcloud
   namespace: flux-system
 spec:
-  interval: 5m
-  url: https://github.com/olipinski/nextcloud-all-in-one
-  ref:
-    branch: ingress-compatibility
-  ignore: |-
-    # exclude all
-    /*
-    # include charts directory
-    !/nextcloud-aio-helm-chart/
+  interval: 1h
+  url: https://nextcloud.github.io/all-in-one/

--- a/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
+++ b/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
@@ -5,7 +5,7 @@ instance:
     kind: GitRepository
     # Changeme!
     url: https://github.com/olipinski/rdx-cluster
-    ref: refs/heads/nextcloud-upstream
+    ref: refs/heads/main
     path: kubernetes/clusters/prod
     interval: 1h
   kustomize:

--- a/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
+++ b/kubernetes/platform/flux-operator/instance/overlays/prod/values.yaml
@@ -5,7 +5,7 @@ instance:
     kind: GitRepository
     # Changeme!
     url: https://github.com/olipinski/rdx-cluster
-    ref: refs/heads/main
+    ref: refs/heads/nextcloud-upstream
     path: kubernetes/clusters/prod
     interval: 1h
   kustomize:


### PR DESCRIPTION
## Changes in this PR

- Switch to Nextcloud upstream chart
  - This will make it easier to maintain
  - And instead of using a fork, we can just patch the `Service`s to not be `Loadbalancer`s